### PR TITLE
Use bundler 2.0 and corresponds to a newer ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.1
-before_install: gem install bundler -v 1.16.2
+before_install:
+  - gem update --system
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.4
+  - 2.5
+  - 2.6
 before_install:
   - gem update --system
   - gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2)
   codacy-coverage
   phc_string_format!
   pry-byebug (~> 3.6)
@@ -96,4 +96,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/phc_string_format.gemspec
+++ b/phc_string_format.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug", "~> 3.6"


### PR DESCRIPTION
Hello naokikimura!

With ruby 2.3 and above, installing bundler newly installs bunlder 2 😉 
Since, even this gem wants to correspond to a new version of bundler .

And try to run CI with ruby 2.5 and 2.6.  🎉 

Pardon my broken English. 🙇 