### PR TITLE
Support ruby 2.7+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 
 gem "rubocop", "~> 0.58.2", require: false, :groups => [:development, :test]
 gem "reek", "~> 5.0", require: false, :groups => [:development, :test]
-gem 'simplecov', require: false, group: :test
-gem 'codacy-coverage', require: false, group: :test
+gem 'simplecov', '>= 0.16.1', require: false, group: :test
+gem 'codacy-coverage', '>= 1.1.8', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     rainbow (3.0.0)
-    rake (10.5.0)
+    rake (13.0.1)
     reek (5.0.2)
       codeclimate-engine-rb (~> 0.4.0)
       kwalify (~> 0.7.0)
@@ -89,7 +89,7 @@ DEPENDENCIES
   codacy-coverage
   phc_string_format!
   pry-byebug (~> 3.6)
-  rake (~> 10.0)
+  rake (~> 13.0)
   reek (~> 5.0)
   rspec (~> 3.0)
   rubocop (~> 0.58.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     equalizer (0.0.11)
     ice_nine (0.11.2)
     jaro_winkler (1.5.1)
-    json (2.1.0)
+    json (2.3.1)
     kwalify (0.7.2)
     method_source (0.9.0)
     parallel (1.12.1)

--- a/lib/phc_string_format/formatter.rb
+++ b/lib/phc_string_format/formatter.rb
@@ -4,7 +4,7 @@ module PhcStringFormat
   #
   module Formatter
     def self.format(**kwargs)
-      PhcString.create(kwargs).to_s
+      PhcString.create(**kwargs).to_s
     end
 
     def self.parse(string, hint: {}, pick: nil)

--- a/phc_string_format.gemspec
+++ b/phc_string_format.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug", "~> 3.6"
 end

--- a/spec/phc_string_format/formatter_spec.rb
+++ b/spec/phc_string_format/formatter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PhcStringFormat::Formatter do
     ]
     test_cases.each do |test_case|
       phc_params = PhcStringFormat::Formatter.parse(test_case)
-      phc_string = PhcStringFormat::Formatter.format(phc_params)
+      phc_string = PhcStringFormat::Formatter.format(**phc_params)
       expect(phc_string).to eq(test_case)
     end
   end

--- a/spec/phc_string_format/phc_string_spec.rb
+++ b/spec/phc_string_format/phc_string_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PhcStringFormat::PhcString do
         salt: ['21f1f94773b7af7e74d437c69c6af6af'].pack('H*'),
         hash: ['0df43c1eff51d9e176b81b35751f7d2068d58c397fae990922468dc99d60de99'].pack('H*')
       }
-      phc_string = PhcStringFormat::PhcString.create(phc_string_parameters)
+      phc_string = PhcStringFormat::PhcString.create(**phc_string_parameters)
       expect(phc_string.to_s).to eq expected
     end
 
@@ -54,7 +54,7 @@ RSpec.describe PhcStringFormat::PhcString do
         salt: ['21f1f94773b7af7e74d437c69c6af6af'].pack('H*'),
         hash: ['0df43c1eff51d9e176b81b35751f7d2068d58c397fae990922468dc99d60de99'].pack('H*')
       }
-      phc_string = PhcStringFormat::PhcString.create(phc_string_parameters)
+      phc_string = PhcStringFormat::PhcString.create(**phc_string_parameters)
       expect(phc_string.to_h).to eq phc_string_parameters
     end
   end


### PR DESCRIPTION
Ruby 3 thinks keyword arguments and hash at the end of parameters are different things.  This pull request fix that.